### PR TITLE
Fix for btoa() with unicode characters

### DIFF
--- a/src/export.ts
+++ b/src/export.ts
@@ -11,7 +11,7 @@ export default function initExport() {
     evt.stopPropagation();
     shared.lineup!.data.exportTable(shared.lineup!.data.getRankings()[0], {}).then((csv) => {
       // download link
-      downloadHelper.href = `data:text/csv;charset=utf-8;base64,${btoa(csv)}`;
+      downloadHelper.href = `data:text/csv;charset=utf-8;base64,${btoa(unescape(encodeURIComponent(csv)))}`;
       (<any>downloadHelper).download = `${shared.dataset!.title}.csv`;
       downloadHelper.click();
     });
@@ -31,7 +31,7 @@ export default function initExport() {
       return r;
     });
     // download link
-    downloadHelper.href = `data:application/json;charset=utf-8;base64,${btoa(JSON.stringify(json))}`;
+    downloadHelper.href = `data:application/json;charset=utf-8;base64,${btoa(JSON.stringify(unescape(encodeURIComponent(json))))}`;
     (<any>downloadHelper).download = `${shared.dataset!.title}.json`;
     downloadHelper.click();
   });


### PR DESCRIPTION
Fixes datavisyn/lineup_app#10

**prerequisites**: 
 * [x] branch is up-to-date with the branch to be merged with, i.e. develop
 * [x] build is successful
 * [x] code is cleaned up and formatted 


### Summary

The download was broken when using unicode characters. I fixed it by adding `btoa(unescape(encodeURIComponent(csv)))` as described here: https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/btoa#Unicode_strings
 
