### PR TITLE
Exlude node_modules except lineup dependencies in webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -95,7 +95,7 @@ module.exports = (_env, options) => {
         },
         {
           test: /\.tsx?$/,
-          exclude: /node_modules/,
+          exclude: /node_modules\/(?!lineupjs|lineupengine)\//, // exlude all node_modules except lineupjs and lineupengine
           use: [{
               loader: 'cache-loader'
             },


### PR DESCRIPTION
Requires PR lineupjs/lineupjs#155

**prerequisites**: 
 * [x] branch is up-to-date with the branch to be merged with, i.e. develop
 * [x] build is successful
 * [x] code is cleaned up and formatted 


### Summary
 
When using the most recent lineupjs dependency (https://github.com/lineupjs/lineupjs/commit/d93d3ca92700cffc145593da8295b9bd39eadbfd) the build of the app fails. The reason is that some typings cannot be found. Including the lineupjs and lineupengine for the TypeScript compiler fixes the problem.

